### PR TITLE
Fix header dict capitalization and add headers

### DIFF
--- a/src/osdf_cache_manager/app.py
+++ b/src/osdf_cache_manager/app.py
@@ -72,13 +72,13 @@ if __name__ == '__main__':
     #############################
     # Schedule Jobs
     #############################
-    @scheduler.task('cron', id='advertise_topo_classads', minute='*/1')
+    @scheduler.task('cron', id='advertise_topo_classads', minute='*/10')
     def advertise_topo_classads():
         print("advertising to collector...") 
         advertise_to_coll(topology_data_src, collector)
         print("advertising done")
         
-    @scheduler.task('cron', id='generate_classads_list', minute='*/1')
+    @scheduler.task('cron', id='generate_classads_list', minute='*/10')
     def generate_classads_list():
         global namespace_ads
         print("Performing scheduled namespace ad generation...")
@@ -103,3 +103,6 @@ if __name__ == '__main__':
     #############################
     serve(app, host='0.0.0.0', port=8443) # use for prod
     #app.run(host='0.0.0.0', port=8443, debug=True) # For debugging, not a production server
+    # Note that when run in debug mode, Flask will create duplicate instances of the app,
+    # which will result in scheduled tasks being run twice. This isn't an issue for debugging,
+    # but it's something to be aware of.

--- a/src/osdf_cache_manager/topology_parser.py
+++ b/src/osdf_cache_manager/topology_parser.py
@@ -26,7 +26,7 @@ def cache_class_ad_from_topo(cache):
 
 def namespace_class_ad_from_topo(namespace, cache):
     authenticated = namespace["readhttps"] or namespace["usetokenonread"]
-    class_ad_dict = {"MyType":"OSDFNamespace", "ServerName":cache["resource"], "Path":namespace["path"], "Authentication":authenticated,"Operations":None}
+    class_ad_dict = {"MyType":"OSDFNamespace", "ServerName":cache["resource"], "Path":namespace["path"], "Authentication":authenticated,"Operations":None, "ReadHTTPS":namespace["readhttps"], "UseTokenOnRead":namespace["usetokenonread"], "DirListHost":namespace["dirlisthost"]}
     
     # Set up supported authorizations
     # THIS SECTION NEEDS REVIEW, IS PROBABLY WRONG

--- a/src/osdf_cache_manager/views.py
+++ b/src/osdf_cache_manager/views.py
@@ -64,22 +64,25 @@ def redirect_to_cache(path):
         namespace_ad = get_namespace_ad(namespace, namespace_ads)
         X_OSDF_Authorization_hdr = ""
         if "Issuer" in namespace_ad: # If there is an issuer, then other fields will also be present
-            X_OSDF_Authorization_hdr = "Issuer={}".format(namespace_ad["Issuer"])
+            X_OSDF_Authorization_hdr = "issuer={}".format(namespace_ad["Issuer"])
             if "BasePath" in namespace_ad:
-                X_OSDF_Authorization_hdr += ", Base-Path={}".format(namespace_ad["BasePath"])
+                X_OSDF_Authorization_hdr += ", base-path={}".format(namespace_ad["BasePath"])
             else:
-                X_OSDF_Authorization_hdr += ", Base-Path={}".format(namespace_ad["Path"])
+                X_OSDF_Authorization_hdr += ", base-path={}".format(namespace_ad["Path"])
             if auth_token:
-                X_OSDF_Authorization_hdr += ", Authorization={}".format(auth_token)
+                X_OSDF_Authorization_hdr += ", authorization={}".format(auth_token)
         response.headers["X-OSDF-Authorizaton"] = X_OSDF_Authorization_hdr
 
         # Create the X-OSDF-Token-Generation header
         X_OSDF_Token_Generation_hdr = ""
         if "Issuer" in namespace_ad: # If there is an issuer, then other fields will also be present  
-            X_OSDF_Token_Generation_hdr = "Issuer={}, Max-Scope-Depth={}, Strategy={}".format(namespace_ad["Issuer"], namespace_ad["MaxScopeDepth"], namespace_ad["Strategy"])
+            X_OSDF_Token_Generation_hdr = "issuer={}, max-scope-depth={}, strategy={}".format(namespace_ad["Issuer"], namespace_ad["MaxScopeDepth"], namespace_ad["Strategy"])
             if "VaultServer" in namespace_ad:
-                X_OSDF_Token_Generation_hdr += ", Vault-Server={}".format(namespace_ad["VaultServer"])
+                X_OSDF_Token_Generation_hdr += ", vault-server={}".format(namespace_ad["VaultServer"])
         response.headers["X-OSDF-Token-Generation"] = X_OSDF_Token_Generation_hdr
+
+
+        response.headers["X-OSDF-Namespace"] = "namespace={}, readhttps={}, use-token-on-read={}".format(namespace, namespace_ad["ReadHTTPS"], namespace_ad["UseTokenOnRead"])
 
         # Headers are all set up, send them back
         return response


### PR DESCRIPTION
Several small updates in this commit:
First, in following RFC 8941, which pertains to structured HTTP headers, dict keys should be entirely lowercase.

Second, the OSDF Client relied on a few more pieces of information from the namespaces.json that the Director didn't provide. Whether the OSDF Client should be reworked to not need the extra info (eg ReadHTTPS and UseTokenOnRead), or should the Director be configured to provide that information remains to be seen. For now, the Director will supply it.

Finally, the app was configured to get the namespaces.json and advertise every minute, a vestige from debugging. The interval was changed to a more reasonable 10 minutes.